### PR TITLE
use new name for hwi_switch_gazebo_ros_control_plugin

### DIFF
--- a/schunk_lwa4d/package.xml
+++ b/schunk_lwa4d/package.xml
@@ -25,6 +25,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>cob_trajectory_controller</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>cob_gazebo_ros_control</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>diagnostic_aggregator</run_depend>
   <run_depend>controller_manager</run_depend>

--- a/schunk_lwa4d/urdf/robot.urdf.xacro
+++ b/schunk_lwa4d/urdf/robot.urdf.xacro
@@ -29,7 +29,7 @@
 
   <!-- gazebo_plugin for arm -->
   <gazebo>
-    <plugin name="ros_control" filename="libmulti_hw_interface_gazebo_ros_control.so">
+    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>arm</robotNamespace>
       <filterJointsParam>joint_names</filterJointsParam>
     </plugin>

--- a/schunk_lwa4p/package.xml
+++ b/schunk_lwa4p/package.xml
@@ -25,6 +25,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>cob_trajectory_controller</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>cob_gazebo_ros_control</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>diagnostic_aggregator</run_depend>
   <run_depend>controller_manager</run_depend>

--- a/schunk_lwa4p/urdf/robot.urdf.xacro
+++ b/schunk_lwa4p/urdf/robot.urdf.xacro
@@ -28,7 +28,7 @@
 
   <!-- gazebo_plugin for arm -->
   <gazebo>
-    <plugin name="ros_control" filename="libmulti_hw_interface_gazebo_ros_control.so">
+    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>arm</robotNamespace>
       <filterJointsParam>joint_names</filterJointsParam>
     </plugin>

--- a/schunk_lwa4p_extended/package.xml
+++ b/schunk_lwa4p_extended/package.xml
@@ -25,6 +25,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>cob_trajectory_controller</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>cob_gazebo_ros_control</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>diagnostic_aggregator</run_depend>
   <run_depend>controller_manager</run_depend>

--- a/schunk_lwa4p_extended/urdf/robot.urdf.xacro
+++ b/schunk_lwa4p_extended/urdf/robot.urdf.xacro
@@ -29,7 +29,7 @@
 
   <!-- gazebo_plugin for arm -->
   <gazebo>
-    <plugin name="ros_control" filename="libmulti_hw_interface_gazebo_ros_control.so">
+    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>arm</robotNamespace>
       <filterJointsParam>joint_names</filterJointsParam>
     </plugin>


### PR DESCRIPTION
requires https://github.com/ipa320/cob_gazebo_plugins/pull/6
